### PR TITLE
readSheetsFromZipFile: fix channel leak

### DIFF
--- a/lib.go
+++ b/lib.go
@@ -814,15 +814,18 @@ func readSheetsFromZipFile(f *zip.File, file *File, sheetXMLMap map[string]strin
 	for j := 0; j < sheetCount; j++ {
 		sheet := <-sheetChan
 		if sheet == nil {
+			// FIXME channel leak
 			return wrap(fmt.Errorf("No sheet returnded from readSheetFromFile"))
 		}
 		if sheet.Error != nil {
+			// FIXME channel leak
 			return wrap(sheet.Error)
 		}
 		sheetName := sheet.Sheet.Name
 		sheetsByName[sheetName] = sheet.Sheet
 		sheets[sheet.Index] = sheet.Sheet
 	}
+	close(sheetChan)
 	return sheetsByName, sheets, nil
 }
 


### PR DESCRIPTION
Close channel when work is done successful.

A few error cases are remaining where the channel is not properly closed. I don't have time to fix them now, but at least they are now properly marked with "FIXME" markers.